### PR TITLE
Tag the default branch as latest

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -32,6 +32,14 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule
+            type=ref,event=tag
+            type=ref,event=pr
+            type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
We let `docker/metadata-action@v4` use the default tagging methods, except for when the branch is the default branch name.  When it is the default branch name, instead of using the branch name to tag the image, it tags it "latest".